### PR TITLE
Remove object for `SparseGrid2D`

### DIFF
--- a/src/engine/fields/sparse_object_grid_2d.rs
+++ b/src/engine/fields/sparse_object_grid_2d.rs
@@ -692,6 +692,9 @@ cfg_if! {
                 let bag = locs.get_mut(loc);
                 if let Some(bag) = bag {
                     bag.retain(|&obj| obj != object);
+                    if bag.is_empty(){
+                        locs.remove(loc);
+                    }
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //!cargo make run --release
 //!```
 //!
-//!In addition to the classical visualization, you can run your krABMaga simulation inside your browser using (*Web Assembly*)<https://webassembly.org>.
+//!In addition to the classical visualization, you can run your krABMaga simulation inside your browser using [*Web Assembly*](https://webassembly.org).
 //!This is possible with the command:
 //!```sh
 //!# Requires 'cargo make' installed


### PR DESCRIPTION
Fixed a bug that can create problems to `get_empy_bag` family methods.
Now when you remove the last object in a specific location, the bag is removed.