### PR TITLE
Remove object for `SparseGrid2D`

### DIFF
--- a/src/engine/fields/sparse_object_grid_2d.rs
+++ b/src/engine/fields/sparse_object_grid_2d.rs
@@ -692,6 +692,9 @@ cfg_if! {
                 let bag = locs.get_mut(loc);
                 if let Some(bag) = bag {
                     bag.retain(|&obj| obj != object);
+                    if bag.is_empty(){
+                        locs.remove(loc);
+                    }
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //!cargo make run --release
 //!```
 //!
-//!In addition to the classical visualization, you can run your krABMaga simulation inside your browser using (*Web Assembly*)<https://webassembly.org>.
+//!In addition to the classical visualization, you can run your krABMaga simulation inside your browser using [*Web Assembly*](https://webassembly.org).
 //!This is possible with the command:
 //!```sh
 //!# Requires 'cargo make' installed

--- a/tests/engine/sparse_object_grid_2d.rs
+++ b/tests/engine/sparse_object_grid_2d.rs
@@ -126,7 +126,7 @@ fn sparse_object_grid_2d_bags() {
     );
 
     let obj = grid.get_objects_unbuffered(&loc);
-    assert_eq!(obj.unwrap().len(), 0);
+    assert!(obj.is_none());
 
     grid.lazy_update();
     let vec = grid.get_empty_bags();

--- a/tests/explore/bayesian.rs
+++ b/tests/explore/bayesian.rs
@@ -5,7 +5,7 @@ use {krabmaga::bayesian_search, krabmaga::explore::bayesian::*};
 #[cfg(any(feature = "bayesian"))]
 #[test]
 fn bayesian() {
-    let (x, y) = bayesian_search!(init_parameters, objective_square, 2, 10, 500, 10.);
+    let (x, y) = bayesian_search!(init_parameters, objective_square, 2, 20, 500, 10.);
 
     println!("---\nFinal res: Point {:?}, val {y}", x);
     assert!(x[0].abs() < 1. && x[1].abs() < 1.);


### PR DESCRIPTION
Fixed a bug that can create problems to `get_empy_bag` family methods.
Now when you remove the last object in a specific location, the bag is removed.