### PR TITLE
Fix Future Deprecation Warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ getrandom = {version="0.2.6", features=["wasm-bindgen"], default-features = fals
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tui = "0.18.0"
 crossterm = "0.23.2"
-sysinfo = "0.24.5"
+sysinfo = "0.27.2"
 plotters = "0.3.1" 
 
 # Must be kept separate and asked to the user due to missing support for conditional compilation of features


### PR DESCRIPTION
The currently used version of  sysinfo (0.24.5) uses ntapi 3.7 which will be deprecated in the future which produces a warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: ntapi v0.3.7)
```
See also `cargo report future-incompatibilities --package ntapi@0.3.7`.

This MR bumps sysinfo to 0.27.2 which removes the warning.