### PR TITLE
Properly add bevy_prototype_lyon bundle for network visualization

### DIFF
--- a/src/visualization/fields/network.rs
+++ b/src/visualization/fields/network.rs
@@ -5,9 +5,11 @@ use std::fmt::Display;
 use std::hash::Hash;
 
 pub use bevy::prelude::Color;
-use bevy::prelude::{Commands, Component, Query, Transform};
+use bevy::prelude::{Commands, Component, Query};
+use bevy::utils::default;
 use bevy_prototype_lyon::draw::{Fill, Stroke};
 use bevy_prototype_lyon::path::ShapePath;
+use bevy_prototype_lyon::prelude::ShapeBundle;
 use bevy_prototype_lyon::prelude::{GeometryBuilder, Path};
 use bevy_prototype_lyon::shapes::Line;
 
@@ -78,13 +80,15 @@ pub trait NetworkRender<O: Hash + Eq + Clone + Display, L: Clone + Hash + Displa
                 } = Self::get_edge_info(edge, network);
 
                 let mut spawn_command = commands.spawn((
-                    GeometryBuilder::build_as(&Line(
-                        Vec2::new(source_loc.x, source_loc.y),
-                        Vec2::new(target_loc.x, target_loc.y),
-                    )),
+                    ShapeBundle {
+                        path: GeometryBuilder::build_as(&Line(
+                            Vec2::new(source_loc.x, source_loc.y),
+                            Vec2::new(target_loc.x, target_loc.y),
+                        )),
+                        ..default()
+                    },
                     Fill::color(Color::BLACK),
                     Stroke::new(line_color, line_width),
-                    Transform::default(),
                 ));
                 if !is_static {
                     spawn_command.insert(EdgeRender(edge.u, edge.v, source_loc, target_loc));

--- a/src/visualization/systems/camera_system.rs
+++ b/src/visualization/systems/camera_system.rs
@@ -1,8 +1,8 @@
+use bevy::prelude::EventReader;
 use bevy::{
     prelude::{Query, Transform},
     window::WindowResized,
 };
-use bevy::prelude::EventReader;
 
 use crate::bevy::prelude::Res;
 use crate::bevy::render::camera::Camera;


### PR DESCRIPTION
The edges weren't being displayed due to other components of the bundle being required.